### PR TITLE
feat: enforce session secret configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Porta do servidor
 PORT=5401
 
+# Secret used to sign session cookies. Rotate periodically.
+SESSION_SECRET=change_me
+
 # URL base da API
 VITE_API_BASE_URL=http://54.232.194.197:5001
 

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -8,8 +8,11 @@ export function getSession() {
   const sessionTtl = 7 * 24 * 60 * 60 * 1000; // 1 week
   const MemoryStoreSession = MemoryStore(session);
 
-  // Generate a secure session secret if not provided
-  const sessionSecret = process.env.SESSION_SECRET || 'As/uEgJuzwRP7JcjDoNcVY41F75KCSNg/c9jew8VIzQ=';
+  // SESSION_SECRET must be provided and rotated periodically
+  const sessionSecret = process.env.SESSION_SECRET;
+  if (!sessionSecret) {
+    throw new Error("SESSION_SECRET environment variable is required");
+  }
 
   return session({
     secret: sessionSecret,


### PR DESCRIPTION
## Summary
- require SESSION_SECRET and instruct rotation in session setup
- document SESSION_SECRET in `.env.example`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(hangs, terminated)*

------
https://chatgpt.com/codex/tasks/task_b_689e0c0ecf48832988c3689c2ae97cd0