### PR TITLE
feat: add env-controlled masked detailed logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,6 @@ DB_SERVER=54.232.194.197
 DB_DATABASE=inventory
 DB_USER=usrInventory
 DB_PASSWORD=inv@2025
+
+# Enable detailed request/response logs
+DETAILED_LOGS=false

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,27 +3,53 @@ import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 
+const SENSITIVE_FIELDS = ["password", "email"];
+
+function maskSensitive(value: any): any {
+  if (Array.isArray(value)) return value.map(maskSensitive);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, val]) =>
+        SENSITIVE_FIELDS.includes(key.toLowerCase())
+          ? [key, "***"]
+          : [key, maskSensitive(val)]
+      ),
+    );
+  }
+  return value;
+}
+
 const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
+
+const detailedLogs =
+  process.env.DETAILED_LOGS === "true" || process.env.DETAILED_LOGS === "1";
 
 app.use((req, res, next) => {
   const start = Date.now();
   const path = req.path;
   let capturedJsonResponse: Record<string, any> | undefined = undefined;
 
-  const originalResJson = res.json;
-  res.json = function (bodyJson, ...args) {
-    capturedJsonResponse = bodyJson;
-    return originalResJson.apply(res, [bodyJson, ...args]);
-  };
+  if (detailedLogs) {
+    const originalResJson = res.json;
+    res.json = function (bodyJson, ...args) {
+      capturedJsonResponse = bodyJson;
+      return originalResJson.apply(res, [bodyJson, ...args]);
+    };
+  }
 
   res.on("finish", () => {
     const duration = Date.now() - start;
     if (path.startsWith("/api")) {
-      let logLine = `${req.method} ${path} ${res.statusCode} in ${duration}ms`;
-      if (capturedJsonResponse) {
-        logLine += ` :: ${JSON.stringify(capturedJsonResponse)}`;
+      let logLine = `${res.statusCode} ${req.method} ${path} in ${duration}ms`;
+
+      if (detailedLogs) {
+        const payload = maskSensitive({
+          request: req.body,
+          response: capturedJsonResponse,
+        });
+        logLine += ` :: ${JSON.stringify(payload)}`;
       }
 
       if (logLine.length > 80) {


### PR DESCRIPTION
## Summary
- log only status, method, path and duration by default
- optionally log masked request/response payloads when `DETAILED_LOGS` is true
- document new `DETAILED_LOGS` setting in `.env.example`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check` (fails: TypeScript errors)


------
https://chatgpt.com/codex/tasks/task_b_689e0e06a690832994c4fecf6d97afbb