### PR TITLE
refactor: log errors instead of throwing

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -66,12 +66,17 @@ app.use((req, res, next) => {
 (async () => {
   const server = await registerRoutes(app);
 
-  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
+  app.use((err: any, _req: Request, res: Response, next: NextFunction) => {
+    log(err?.stack || err?.message || String(err), "error");
+
+    if (res.headersSent) {
+      return next(err);
+    }
+
     const status = err.status || err.statusCode || 500;
     const message = err.message || "Internal Server Error";
 
     res.status(status).json({ message });
-    throw err;
   });
 
   // importantly only setup vite in development and after


### PR DESCRIPTION
## Summary
- log errors in the express error handler instead of throwing them
- forward errors to the next middleware when headers are already sent

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: TypeScript errors in other files)*

------
https://chatgpt.com/codex/tasks/task_b_689e141acdec83299b6475640d8d50fb